### PR TITLE
Make format() synchronous

### DIFF
--- a/explainer-metrics.md
+++ b/explainer-metrics.md
@@ -8,7 +8,7 @@ the data model for formatted text. We aspire to create these metrics in a way th
 to be supported for other sources of inline text content, in particular the DOM or a Worklet's
 Layout API algorithm.
 Additional scenarios include different web application rendering systems which can make use of
-the text shaping information to perform their own rendering logic. For example WebGL based apps 
+the text shaping information to perform their own rendering logic. For example WebGL based apps
 with text content. The metrics would be used to determine how to correctly position glyphs in a
 typographically correct manner.
 
@@ -17,7 +17,7 @@ and the use cases supporting the rendering of glyphs as described therein, as we
 notion of a Position object.
 
 For a general overview of the feature, see the repo's [readme](README.md).
-You can also learn more about the [formatted text data model](explainer-datamodel.md) and 
+You can also learn more about the [formatted text data model](explainer-datamodel.md) and
 [how to render it](explainer-rendering.md).
 
 # Use cases
@@ -27,23 +27,23 @@ You can also learn more about the [formatted text data model](explainer-datamode
 ### Use case: paragraph placement
 
 This use case is the most basic use case we can imagine--identifying the placement of some
-Formatted Text into a view layer (like Canvas). Placement needs two things, a reference 
+Formatted Text into a view layer (like Canvas). Placement needs two things, a reference
 coordinate (x/y) and size metrics (bounding box of width/height).
 
-Author provides: 
+Author provides:
 
 * input `FormattedText` object (including styled runs, where styles may include runs with
-   differing font characteristics, line-spacing, justification rules, etc.) 
-* line-wrap constraints (width constraint in horizontal languages) 
+   differing font characteristics, line-spacing, justification rules, etc.)
+* line-wrap constraints (width constraint in horizontal languages)
 
-Metrics provide: 
+Metrics provide:
 
-* Final shaped and formatted paragraph width and height. 
+* Final shaped and formatted paragraph width and height.
 
-A rendering API must provide: 
+A rendering API must provide:
 
-* (x, y) location to place the formatted paragraph. (Authors ensure paragraph will fit in 
-   the space provided by their data model. If not, they can adjust font-size, line-width, 
+* (x, y) location to place the formatted paragraph. (Authors ensure paragraph will fit in
+   the space provided by their data model. If not, they can adjust font-size, line-width,
    line-spacing, etc., on the original `FormattedText` objects and re-request metrics until
    the desired goal is met.
 
@@ -52,31 +52,31 @@ A rendering API must provide:
 In this case, the author would like the platform to calculate line wrapping, but intends to
 render each line iteratively (such as for captions), or with custom spacing, etc.
 
-Author provides same information as above. 
+Author provides same information as above.
 
-Metrics provide: 
+Metrics provide:
 * Access to formatted line objects with width and height (including their offsets from the
    paragraph container)
 * Pointers back to the input characters for the bounds positions of each line.
 
-A rendering API must provide: 
+A rendering API must provide:
 
-* (x, y) location to place formatted line 
+* (x, y) location to place formatted line
 
 ### Use Case: specific glyph placement
 
 ⚠🚧 We would like to validate this use case for Canvas 2D scenarios. For WebGL scenarios, we
 understand the key information needed for rendering is the given shaped font's glyph id and
-glyph advance information. Is a Canvas 2d rendering API needed? A sketch of how this might 
+glyph advance information. Is a Canvas 2d rendering API needed? A sketch of how this might
 work follows.
 
-Author provides same information as in the previous use case. 
+Author provides same information as in the previous use case.
 
-Metrics provide: 
+Metrics provide:
 
 * List of Shaped Glyph metrics per fragment (fragment is a unit of glyphs that all share the
-   same format/font/bidi/etc.). 
-* Pointers back to the input characters for each glyph's bounds. 
+   same format/font/bidi/etc.).
+* Pointers back to the input characters for each glyph's bounds.
 
 A rendering API must provide:
 
@@ -95,28 +95,28 @@ these metrics and their source `FormattedText` objects.
 
 ### Rendering a selection over text (and placing/moving a caret)
 
-Author provides: 
+Author provides:
 
-* Input data model (same as previously described). 
-* JS objects for tracking selection anchor and focus locations in the input data model (i.e., 
+* Input data model (same as previously described).
+* JS objects for tracking selection anchor and focus locations in the input data model (i.e.,
    reference to a `FormattedTextRun` and character offset).
 
 Metrics provide:
 
 * Position objects that map line/fragment/glyph indexes to input data model runs/offsets.
    (Map from text metrics to data model.)
-* API for obtaining position objects given input data model runs/offsets. (Map from 
+* API for obtaining position objects given input data model runs/offsets. (Map from
    data model to text metrics.)
 * API for obtaining position objects given (x,y) offsets relative to the formatted paragraph.
    (Map for mouse/touch/pen input to text metrics and data model.)
 * Access to formatted line objects with width/height (bounding box) and offsets from their
-   container. 
+   container.
 * Access to formatted fragments within lines with width/height (bounding box) and offset from
    their container (if a selection needs to be tightly bound around the formatted glyph runs
    inside of lines).
-* Access to glyph width/height (bounding box) and offset from the fragment container. 
+* Access to glyph width/height (bounding box) and offset from the fragment container.
 
-A rendering API does not need to provide specific features (other than those noted in previous 
+A rendering API does not need to provide specific features (other than those noted in previous
 use cases) for this scenario. (e.g., rendering a selction and caret can be done with existing
 APIs).
 
@@ -134,17 +134,17 @@ goal to introduce these new CSS layout models to `FormattedText`. Instead, we wi
 calculate the placement of the formatted text themselves. To do this, the metrics API will provide
 both the inline and **block size** values.
 
-In order to get the data model's inline and block size, the `FormattedText` object must be… well, 
+In order to get the data model's inline and block size, the `FormattedText` object must be… well,
 formatted.
 
-A new API is added to the `FormattedText` object: **format()**. This API takes a maximum inline size 
-parameter and asynchronously returns a **formatted paragraph object** containing the inline size and
+A new API is added to the `FormattedText` object: **format()**. This API takes a maximum inline size
+parameter and synchronously returns a **formatted paragraph object** containing the inline size and
 block size (among other things) after running all shaping, line breaking, and formatting of the text.
 This paragraph object **is a snapshot** of metrics for the `FormattedText` data model, given the
 constraints applied at the time of formatting, and is **not updated** as additional changes are made
 to the data model.
 
-The formatted paragraph is a container for all the input data model's metrics. It contains the APIs 
+The formatted paragraph is a container for all the input data model's metrics. It contains the APIs
 to get additional line, fragment, and glyph information. The object hierarchy is shown below (note
 the image shows lines in a horizontal writing mode--but vertical writing modes are supported):
 
@@ -156,19 +156,19 @@ glyphs from a fragment (see [Rendering section](explainer-rendering.md)).
 
 | New APIs on `FormattedText` | Description |
 |---|---|
-| .`format`(`inlineSize`) | Asynchronously formats the `FormattedText` object, returning an object suitable for rendering and extracting metrics: a `FormattedTextParagraph` |
+| .`format`(`inlineSize`) | Synchronously formats the `FormattedText` object, returning an object suitable for rendering and extracting metrics: a `FormattedTextParagraph` |
 
 ## Metrics lifetime expectations
 
-⚠🚧 We encourage prototyping to get feedback about the implementation opportunities or complexities 
+⚠🚧 We encourage prototyping to get feedback about the implementation opportunities or complexities
 of this suggested approach.
 
-It seems likely that developers will want to `format` their `FormattedText` frequently (for example, 
-as the model is changed to respond to user actions). Because metrics objects are snapshots, this 
+It seems likely that developers will want to `format` their `FormattedText` frequently (for example,
+as the model is changed to respond to user actions). Because metrics objects are snapshots, this
 could lead to an accumulation of many copies of metrics, only the most recent of such is relevant to
-the latest data model udpates at any given time. One approach, to avoid unnecessary pressure on the 
+the latest data model udpates at any given time. One approach, to avoid unnecessary pressure on the
 garbage collector, is to return the same instance of one or all of the metrics objects each time
-`format` is called. If a portion of the metrics have changed, then the objects related to those 
+`format` is called. If a portion of the metrics have changed, then the objects related to those
 metrics would be new instances, while the other unchanged metrics would be same-instance identical.
 
 A downside to this approach is that authors wouldn't necessarily be able to depend on getting back
@@ -177,18 +177,18 @@ the same object identity all the time. For example, JavaScript properties added 
 is returned, the author's extra JavaScript properties will be missing.
 
 Our recommendation is a hybrid approach. New objects shall be created every time `format` is called.
-This allows us to provide clear author expectations. However, to allow implementations to optimize, 
-only **one copy** of the metrics objects (the one most recently returned from `format`) will be 
+This allows us to provide clear author expectations. However, to allow implementations to optimize,
+only **one copy** of the metrics objects (the one most recently returned from `format`) will be
 "operable" at any one time. Prior copies of metrics objects will be internally disabled such that API
 calls on them will throw exceptions.
 
 ## Thinking ahead: future integration into DOM or Houdini Layout API
 
-⚠🚧 WARNING: This section is entirely speculative, and out of scope for now. We include it here 
+⚠🚧 WARNING: This section is entirely speculative, and out of scope for now. We include it here
 to ponder extended use cases in which these metrics could be applicable in the wider web platform.
 (And not to lose track of them in the design process.)
 
-The opportunity to get detailed metrics for formatted text is not exclusively tied to scenarios 
+The opportunity to get detailed metrics for formatted text is not exclusively tied to scenarios
 where DOM is potentially unavailable or impractical to use. We would like to ensure that we design
 for the possibility of integration into both DOM and Layout API scenarios as well.
 
@@ -201,14 +201,14 @@ existing API [`getClientRects()`](https://drafts.csswg.org/cssom-view/#dom-eleme
 with line metric information.
 
 In the Layout API, while processing a `layout`, `LayoutFragment` objects can represent a line of text.
-In these situations, it might make sense to extend the `LayoutFragment` by combining it with a 
+In these situations, it might make sense to extend the `LayoutFragment` by combining it with a
 `FormattedTextLine` metrics object. This would provide extra information about the intra-line fragments
 and glyph information, potentially allowing advanced positioning of glyphs within a line-layout pass.
 
 | ⚠🚧 Ideas for integration into other parts of the platform | Description |
 |---|---|
 | myElement.`measureFormattedText`() | Similar to `format`. TBD on scope of how this would work 😊 |
-| `extDOMRect`.`textFragments`[`i`] | Alternative DOM integration point that extends `getClientRects()` such that each rectangle gets the `FormattedTextLine` mixin or some such. | 
+| `extDOMRect`.`textFragments`[`i`] | Alternative DOM integration point that extends `getClientRects()` such that each rectangle gets the `FormattedTextLine` mixin or some such. |
 | `extLayoutFrag`.`textFragments`[`i`] | Array of `FormattedTextFragments` (see equivalent functionality in a `FormattedTextLine` object). |
 
 # Formatted text metrics objects
@@ -222,7 +222,7 @@ This is the top-level container returned by formatting a FormattedText object. I
 * a coordinate system for its lines (see section below).
 * Utility function for getting a position from a character and text run in the data model (position
    objects described below).
-* Utility function for getting a position from an x/y coordinate pair (where the x/y coordinates 
+* Utility function for getting a position from an x/y coordinate pair (where the x/y coordinates
    should be relative to the paragraph's coordinate system.
 
 | APIs on `FormattedTextParagraph` | Description |
@@ -235,13 +235,13 @@ This is the top-level container returned by formatting a FormattedText object. I
 
 ### Thoughts on coordinate systems
 
-This API is designed with multiple writing modes (i.e., horizontal and vertical text) in mind. To 
+This API is designed with multiple writing modes (i.e., horizontal and vertical text) in mind. To
 an author used to `ltr` direction and `horizontal-tb` block progression, having coordinates originate
 in the upper-left of some object's bounding box makes sense. We assert that in other writing modes
-the coordiante origin should align with the expectations of that layout mode. For example, if the 
+the coordiante origin should align with the expectations of that layout mode. For example, if the
 inline direction is top-to-bottom, starting at the right edge with block progression growing to the
 left, then the coordinate origin makes more sense in the upper-right of an object's bounding box. It
-is our intent then that when expressing coordinate positions, the origin is relative to the defined 
+is our intent then that when expressing coordinate positions, the origin is relative to the defined
 (or implied) writing mode used in the `FormattedText` object.
 
 We acknowledge that the Canvas coordinate systems (e.g., 2d canvas and WebGL) are fixed, meaning that
@@ -250,17 +250,17 @@ formatted text objects into a canvas.
 
 We also considered **relative coordinate systems** for each "layer" of the nested objects in the
 formatted text metrics. For example, fragments inside of lines would have coordinate offsets that were
-**relative** to the line's origin. Such an approach only tends to add complication for authors who 
+**relative** to the line's origin. Such an approach only tends to add complication for authors who
 will need to compute absolute offsets when working outside of the formatted text metrics (for example,
 in a canvas while responding to pointer events). For this reason, offset information at every step of
-the metrics API are **absolute** offsets from the origin of the formatted text paragraph (with one 
+the metrics API are **absolute** offsets from the origin of the formatted text paragraph (with one
 exception: glyph advances).
 
 Using abolute offsets for every object may need to be revisited when considering metrics reported only
 for paragraph sub-parts (e.g., in the Layout API where there may be no paragraph objects available).
 
 For glyphs, the most vital piece of information for determining the position of the following glyph (in
-either horizontal or vertical orientation) is the `**advance**`. The value of `advance` is always 
+either horizontal or vertical orientation) is the `**advance**`. The value of `advance` is always
 relataive for each glyph, and has already incorporated kerning for adjacent glyphs.
 
 ## Positions – `FormattedTextPosition`
@@ -268,7 +268,7 @@ relataive for each glyph, and has already incorporated kerning for adjacent glyp
 Inspired by the
 [TextPosition](https://github.com/google/skia/blob/main/site/docs/dev/design/text_shaper.md#access-the-results-of-shaping-and-formatting)
 design, a `FormattedTextPosition` object provides the mapping between the formatted snapshot of the data
-model (e.g., the paragraph, lines, fragments and glyphs) and the data model itself, which contains the 
+model (e.g., the paragraph, lines, fragments and glyphs) and the data model itself, which contains the
 source characters (Unicode code points) and their CSS-styled text runs. Positions always connect glyphs
 with characters and contain all necessary indexes to navigate the object structures to get between glyphs
 and characters. Like the rest of the formatted objects, positions are snapshots, and not updated as the
@@ -301,8 +301,8 @@ These are covered below in the fragments section.
 
 ## Lines – `FormattedTextLine`
 
-The line is the bounding box of all the formatted fragments contained within the line (it has no 
-formatting itself). All fragments contained within the line are wholly contained within (no fragments 
+The line is the bounding box of all the formatted fragments contained within the line (it has no
+formatting itself). All fragments contained within the line are wholly contained within (no fragments
 exist simultaneously in multiple lines). Note: due to justification or other inline alignment properties
 of the line, the line sizes and offsets may vary. The line's offsets are relative to the origin of its
 parent `FormattedTextParagraph` object.
@@ -328,20 +328,20 @@ The line provides:
 
 ## Fragments – `FormattedTextFragment`
 
-The fragment is the smallest unit of same-formatted text in a line. Fragments always have consistent 
-directionality (they are post-BIDI algorithm processed, where alternating bidi sequences are split 
+The fragment is the smallest unit of same-formatted text in a line. Fragments always have consistent
+directionality (they are post-BIDI algorithm processed, where alternating bidi sequences are split
 into separate fragments). All glyphs within have the same font shaping properties applied. Because
-of these properties, the fragment metrics are quite similar to the information exposed through 
+of these properties, the fragment metrics are quite similar to the information exposed through
 [`measureText()`](https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-measuretext).
-Consequently, the `FormattedTextFragment` extends the 
+Consequently, the `FormattedTextFragment` extends the
 [`TextMetrics`](https://html.spec.whatwg.org/multipage/canvas.html#textmetrics) interface.
 
 The fragment also holds all the glyph information. The glyph information is to be understood in the
 context of the fragment's format (its font metrics).
 
-Note: the `FormattedTextFragment` and future 
+Note: the `FormattedTextFragment` and future
 [Font Metrics API](https://drafts.css-houdini.org/font-metrics-api/#fontmetrics) could be combined,
-though in this context the fragment is guaranteed to have consistent font metrics, so things like 
+though in this context the fragment is guaranteed to have consistent font metrics, so things like
 the FontMetrics' `fonts` (a list) wouldn't apply.
 
 A Fragment object provides:
@@ -349,11 +349,11 @@ A Fragment object provides:
 * x/y offsets (from the paragraph's coordinate origin)
 * Everything on HTML's
    [`TextMetrics`](https://html.spec.whatwg.org/multipage/canvas.html#textmetrics) interface
-* ⚠🚧 Formatting result values (for font, etc.). Note: we would like to understand the use cases 
+* ⚠🚧 Formatting result values (for font, etc.). Note: we would like to understand the use cases
    for some of these better.
 * Array of glyph information
 * ⚠🚧 Potentially add baseline information (relative to the line) depending on use case?
-* Utility functions for getting the start position and end position of the characters that bookend 
+* Utility functions for getting the start position and end position of the characters that bookend
    the fragment (e.g., the ability to identify where the fragment starts and ends in the data model).
 * Utility function for getting a position for an arbitrary glyph in the fragment
 
@@ -376,7 +376,7 @@ To form glyphs, font files have processing rules that are font-specific that det
 characters are mapped to particular glyphs. The presentation of a glyph may be processed differently
 depending on the font. For base ASCII characters the mapping is typically trivial--one character is
 associated with one glyph. However, for combining characters (and similar), font behavior may vary.
-For example, a font may map `á` (U+00E1 Latin Small Letter A with Acute) to a single glyph geometry 
+For example, a font may map `á` (U+00E1 Latin Small Letter A with Acute) to a single glyph geometry
 (statically or through a processing table). Another font might cause two glyphs (the decomposition of
 the glyph `á` into `a` U+0061 Latin Small Letter A and `◌́ ` U+0301 Combining Acute Accent) to be used
 and will alter the advance logic so that the comining character glyph is painted in the same
@@ -385,7 +385,7 @@ location as the `a`.
 ⚠🚧 We expect that additional experimentation is required to work out the best API given the range of
 possibilities and font combinations that exist.
 
-Our early thoughts are to model all cases where multiple glyphs are used for combining characters 
+Our early thoughts are to model all cases where multiple glyphs are used for combining characters
 as unique fragments. Thus, within a fragment we can assert that the set of glyphs with will always
 have positive advances. When a combining character (or string of them) is encountered, such a character
 would be placed into its own fragment object, and the offset of that fragment would overlap the previous
@@ -402,8 +402,8 @@ Plain JS object with keys/values:
 * id - this glyph's font-specific index code (into the font). May be `null` for installed fonts.
 
 ⚠🚧 There are lots of interesting metrics for glyphs; however, we'll want to understand use cases
-that necessitate exposing more information (e.g., `x`/`y` origin, `bearing`, bounding box geometry, 
-applied kerning, actual geometry like Path2D data, raw `ImageData`, etc.). Modeling a glyph with a 
+that necessitate exposing more information (e.g., `x`/`y` origin, `bearing`, bounding box geometry,
+applied kerning, actual geometry like Path2D data, raw `ImageData`, etc.). Modeling a glyph with a
 JavaScript object allows for easy extensibility. Alternatively, with only `advance` and `id`, this
 information could be expressed as arrays.
 
@@ -412,8 +412,8 @@ information could be expressed as arrays.
 **Word bounds/breaks** - meta-data about "word" breaks opportunities are not exposed to the developer
 today. In the current propsoal, the identification of word breaks is left as an activity to be
 supported by author code. Note that word-breaking for the purpose of line wrapping and formatting
-is in scope for this feature. However once the layout has been calculated, author code will need 
-to use heuristics in langugues that have natural word breaks (e.g., via spaces between words). 
+is in scope for this feature. However once the layout has been calculated, author code will need
+to use heuristics in langugues that have natural word breaks (e.g., via spaces between words).
 Developer feedback on whether native metrics should be support for word-breaks is sought and may
 motivate additional work.
 


### PR DESCRIPTION
Fixes https://github.com/WICG/canvas-formatted-text/issues/24.

(My VSCode is configured to remove trailing whitespace automatically. LMK if this is annoying and I'll revert.)